### PR TITLE
Add simple print

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-altinn-python"
-version = "0.0.5"
+version = "0.0.6"
 description = "SSB Altinn Python"
 authors = ["Øyvind Bruer-Skarsbø <obr@ssb.no>"]
 license = "MIT"

--- a/src/altinn/file.py
+++ b/src/altinn/file.py
@@ -63,3 +63,9 @@ class FileInfo:
         dom = parseString(fs.cat_file(self.file_path))
         pretty_xml = dom.toprettyxml(indent="  ")
         print(pretty_xml)
+
+    def print(self) -> None:
+        """Print unformatted version of an XML file."""
+        fs = FileClient.get_gcs_file_system()
+        file = fs.cat_file(self.file_path)
+        print(file.decode())


### PR DESCRIPTION
Adding a printing-option for invalid xml-files that cant be parsed. Enables staticians to see whats wrong from their IDE. 