### PR TITLE
isee-transform

### DIFF
--- a/src/altinn/flatten.py
+++ b/src/altinn/flatten.py
@@ -64,9 +64,9 @@ def isee_transform(file_path, mapping=None):
         "InternInfo_enhetsType": "Enhets_type",
     }
 
-    df_isee = df_isee.melt(intern_cols, var_name="feltnavn", value_name="feltverdi").rename(
-        columns=isee_rename
-    )
+    df_isee = df_isee.melt(
+        intern_cols, var_name="feltnavn", value_name="feltverdi"
+    ).rename(columns=isee_rename)
 
     df_isee["feltnavn"] = (
         df_isee["feltnavn"]
@@ -77,6 +77,5 @@ def isee_transform(file_path, mapping=None):
     if mapping is not None:
         df_isee["feltnavn"].replace(mapping, inplace=True)
 
-    df_isee['version_nr'] = angiver_id
-
+    df_isee["version_nr"] = angiver_id
     return df_isee


### PR DESCRIPTION
The function:
- Selects the SkjemaData columns and the columns needed from InternInfo
- Transposes the skjemadata colums from wide to long using melt
- Renames columns to align with the ISEE format
- Removes the numerical suffixes in the feltnavn column in the cases where there are multiple occurences of a leaf element. Trailing underscores are also removed.
- Renames the feltnavn variables to the ISEE variable names from the inputted dictionary.
- Sets the angiver_id as "version_nr". The angiver ID is also included as a separate row.