### PR TITLE
ssb-altinn-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-altinn-python"
-version = "0.3.4"
+version = "0.3.5"
 description = "SSB Altinn Python"
 authors = ["Øyvind Bruer-Skarsbø <obr@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Removed `is_dapla()`-fn and replaced it with an `is_gcs()`-function that is not reliant on an environment variable in Jupyter Dapla. 