### PR TITLE
Checkbox support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-altinn-python"
-version = "0.4.6"
+version = "0.4.7"
 description = "SSB Altinn Python"
 authors = ["Vidar Strandseter <vidar.strandseter@ssb.no>"]
 license = "MIT"

--- a/src/altinn/flatten.py
+++ b/src/altinn/flatten.py
@@ -80,7 +80,7 @@ def _flatten_dict(d: Any, parent_key: str = "", sep: str = "_") -> Any:
 
 
 def _transform_dict_checkbox_var(
-    dictionary: dict, old_key: str, new_value: str = "1"
+    dictionary: dict[str, str], old_key: str, new_value: str = "1"
 ) -> dict:
     """transform_dict_code_vars.
 

--- a/src/altinn/flatten.py
+++ b/src/altinn/flatten.py
@@ -81,7 +81,7 @@ def _flatten_dict(d: Any, parent_key: str = "", sep: str = "_") -> Any:
 
 def _transform_dict_checkbox_var(
     dictionary: dict[str, str], old_key: str, new_value: str = "1"
-) -> dict:
+) -> dict[str, str]:
     """transform_dict_code_vars.
 
     Transform a dictionary by removing a key and using its value as a new key with a new value.
@@ -96,7 +96,7 @@ def _transform_dict_checkbox_var(
     """
     value = dictionary.pop(old_key, None)
 
-    values = utils._split_string(value)
+    values = utils._split_string(value)  # type: ignore
     for value in values:
         dictionary[value] = new_value
 
@@ -257,7 +257,7 @@ def _add_lopenr(df: pd.DataFrame) -> pd.DataFrame:
 def isee_transform(
     file_path: str,
     mapping: Optional[dict[str, str]] = None,
-    checkbox_vars: list[str] = None,
+    checkbox_vars: Optional[list[str]] = None,
 ) -> pd.DataFrame:
     """Transforms a XML to ISEE-format using xmltodict.
 
@@ -282,8 +282,6 @@ def isee_transform(
     """
     if utils.is_valid_xml(file_path):
         if _validate_interninfo(file_path):
-            if mapping is None:
-                mapping = {}
 
             xml_dict = _read_single_xml_to_dict(file_path)
             root_element = next(iter(xml_dict.keys()))

--- a/src/altinn/flatten.py
+++ b/src/altinn/flatten.py
@@ -79,22 +79,24 @@ def _flatten_dict(d: Any, parent_key: str = "", sep: str = "_") -> Any:
     return dict(items)
 
 
-def _transform_dict_checkbox_var(dictionary:dict, old_key:str, new_value:str="1")->dict:
+def _transform_dict_checkbox_var(
+    dictionary: dict, old_key: str, new_value: str = "1"
+) -> dict:
     """transform_dict_code_vars.
-    
+
     Transform a dictionary by removing a key and using its value as a new key with a new value.
 
     Args:
         dictionary: The dictionary to be transformed.
         old_key: The key to remove from the dictionary.
+        new_value: Optional new value to add, default is 1 as str.
 
     Returns:
         dict: The transformed dictionary.
     """
     value = dictionary.pop(old_key, None)
-    
+
     values = utils.split_string(value)
-    print(values)
     for value in values:
         dictionary[value] = new_value
 
@@ -253,7 +255,9 @@ def _add_lopenr(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def isee_transform(
-    file_path: str, mapping: Optional[dict[str, str]] = None, checkbox_vars:list[str] = None,
+    file_path: str,
+    mapping: Optional[dict[str, str]] = None,
+    checkbox_vars: list[str] = None,
 ) -> pd.DataFrame:
     """Transforms a XML to ISEE-format using xmltodict.
 
@@ -267,7 +271,7 @@ def isee_transform(
         mapping: The mapping dictionary to map variable names in the
             'feltnavn' column. The default value is an empty dictionary
             (if mapping is not needed).
-        code_vars: Optional list of str for elements from xml containing KLASS codes.
+        checkbox_vars: Optional list of str for elements from xml containing KLASS codes.
 
     Returns:
         pandas.DataFrame: A transformed DataFrame which aligns with the
@@ -286,10 +290,10 @@ def isee_transform(
             input_dict = xml_dict[root_element]["SkjemaData"]
 
             final_dict = _flatten_dict(input_dict)
-            
+
             if checkbox_vars is not None:
                 for checkbox_var in checkbox_vars:
-                    final_dict = _transform_dict_checkbox_var(final_dict,checkbox_var)
+                    final_dict = _transform_dict_checkbox_var(final_dict, checkbox_var)
 
             final_df = pd.DataFrame(
                 list(final_dict.items()), columns=["FELTNAVN", "FELTVERDI"]

--- a/src/altinn/flatten.py
+++ b/src/altinn/flatten.py
@@ -79,6 +79,28 @@ def _flatten_dict(d: Any, parent_key: str = "", sep: str = "_") -> Any:
     return dict(items)
 
 
+def _transform_dict_checkbox_var(dictionary:dict, old_key:str, new_value:str="1")->dict:
+    """transform_dict_code_vars.
+    
+    Transform a dictionary by removing a key and using its value as a new key with a new value.
+
+    Args:
+        dictionary: The dictionary to be transformed.
+        old_key: The key to remove from the dictionary.
+
+    Returns:
+        dict: The transformed dictionary.
+    """
+    value = dictionary.pop(old_key, None)
+    
+    values = utils.split_string(value)
+    print(values)
+    for value in values:
+        dictionary[value] = new_value
+
+    return dictionary
+
+
 def _validate_interninfo(file_path: str) -> bool:
     """Validate interninfo.
 
@@ -231,7 +253,7 @@ def _add_lopenr(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def isee_transform(
-    file_path: str, mapping: Optional[dict[str, str]] = None
+    file_path: str, mapping: Optional[dict[str, str]] = None, checkbox_vars:list[str] = None,
 ) -> pd.DataFrame:
     """Transforms a XML to ISEE-format using xmltodict.
 
@@ -245,6 +267,7 @@ def isee_transform(
         mapping: The mapping dictionary to map variable names in the
             'feltnavn' column. The default value is an empty dictionary
             (if mapping is not needed).
+        code_vars: Optional list of str for elements from xml containing KLASS codes.
 
     Returns:
         pandas.DataFrame: A transformed DataFrame which aligns with the
@@ -263,6 +286,10 @@ def isee_transform(
             input_dict = xml_dict[root_element]["SkjemaData"]
 
             final_dict = _flatten_dict(input_dict)
+            
+            if checkbox_vars is not None:
+                for checkbox_var in checkbox_vars:
+                    final_dict = _transform_dict_checkbox_var(final_dict,checkbox_var)
 
             final_df = pd.DataFrame(
                 list(final_dict.items()), columns=["FELTNAVN", "FELTVERDI"]

--- a/src/altinn/flatten.py
+++ b/src/altinn/flatten.py
@@ -96,7 +96,7 @@ def _transform_dict_checkbox_var(
     """
     value = dictionary.pop(old_key, None)
 
-    values = utils.split_string(value)
+    values = utils._split_string(value)
     for value in values:
         dictionary[value] = new_value
 

--- a/src/altinn/utils.py
+++ b/src/altinn/utils.py
@@ -48,7 +48,7 @@ def is_valid_xml(file_path: str) -> bool:
             return False
 
 
-def _split_string(input_string: str):
+def _split_string(input_string: str) -> list[str]:
     """Split a string into a list of strings using ',' as the separator.
 
     Args:

--- a/src/altinn/utils.py
+++ b/src/altinn/utils.py
@@ -46,3 +46,16 @@ def is_valid_xml(file_path: str) -> bool:
                 return True
         except (ParseError, OSError):
             return False
+
+
+def _split_string(input_string:str):
+    """
+    Split a string into a list of strings using ',' as the separator.
+
+    Args:
+        input_string: The input string to be split.
+
+    Returns:
+        list: A list of split strings.
+    """
+    return input_string.split(',')

--- a/src/altinn/utils.py
+++ b/src/altinn/utils.py
@@ -48,9 +48,8 @@ def is_valid_xml(file_path: str) -> bool:
             return False
 
 
-def _split_string(input_string:str):
-    """
-    Split a string into a list of strings using ',' as the separator.
+def _split_string(input_string: str):
+    """Split a string into a list of strings using ',' as the separator.
 
     Args:
         input_string: The input string to be split.
@@ -58,4 +57,4 @@ def _split_string(input_string:str):
     Returns:
         list: A list of split strings.
     """
-    return input_string.split(',')
+    return input_string.split(",")


### PR DESCRIPTION
Nåværende isee_transform klarer ikke å håndtere basic checkboxes. Det gjør at du kun kan bruke funksjonen på de enkleste skjemaene. Her er en fiks for checkboxes. Det brukes av flere statistikker i vår seksjon og er helt nødvendig for at vi skal kunne bruke altinn 3 skjemaer. 

Logikken er å ta en dict value å transformere den til flere dict keys.

{"a":"x,y,z"}
lager liste av values

["x","y","z"]

legger liste values inn i dicten som keys, med value "1"

{
"x":"1",
"y":"1",
"z":"1",
}

Herfra kan dataen håndteres som vanlig og vil kunne lastes opp til oracle.