### PR TITLE
Checkbox support for altinn3 xml skjemaer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-altinn-python"
-version = "0.4.7"
+version = "0.4.8"
 description = "SSB Altinn Python"
 authors = ["Vidar Strandseter <vidar.strandseter@ssb.no>"]
 license = "MIT"

--- a/src/altinn/utils.py
+++ b/src/altinn/utils.py
@@ -46,3 +46,15 @@ def is_valid_xml(file_path: str) -> bool:
                 return True
         except (ParseError, OSError):
             return False
+
+
+def _split_string(input_string: str) -> list[str]:
+    """Split a string into a list of strings using ',' as the separator.
+
+    Args:
+        input_string: The input string to be split.
+
+    Returns:
+        list: A list of split strings.
+    """
+    return input_string.split(",")


### PR DESCRIPTION
Da er ting på plass. 

Nåværende isee_transform klarer ikke å håndtere basic checkboxes. Det gjør at du kun kan bruke funksjonen på de enkleste skjemaene. Her er en fiks for checkboxes. Det brukes av flere statistikker i vår seksjon og er helt nødvendig for at vi skal kunne bruke altinn 3 skjemaer.

Logikken er å ta en dict value å transformere den til flere dict keys.

{"a":"x,y,z"}
lager liste av values

["x","y","z"]

legger liste values inn i dicten som keys, med value "1"

{
"x":"1",
"y":"1",
"z":"1",
}

Herfra kan dataen håndteres som vanlig og vil kunne lastes opp til oracle.

![image](https://github.com/statisticsnorway/ssb-altinn-python/assets/132445493/77a0080f-4d41-4ffc-8312-dff151c0ce49)


Det må også være med en bool basert på om du har unike kode verdier eller ikke. RA-0187 bruker for eksempel koder fra tabell 689 i klass. NØKU har skjemaer som ikke bruker kodeverdier i klass. Dermed er ikke kodeverdiene unike og det må lages unike keys som kan mappes. Eksempel skjema er ra-1407 fra s423.

![image](https://github.com/statisticsnorway/ssb-altinn-python/assets/132445493/9463b077-da9c-4ebf-a2b9-93139d31f3e7)

Må bli!

![image](https://github.com/statisticsnorway/ssb-altinn-python/assets/132445493/d12e7bbe-0de1-4dee-b44b-c087bdb458d0)

Hvor key elementet og koden blir slått sammen for å lage en unik key som kan mappes. 