### PR TITLE
Release 0.4.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssb-altinn-python"
-version = "0.4.11"
+version = "0.4.12"
 description = "SSB Altinn Python"
 authors = ["Vidar Strandseter <vidar.strandseter@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Added check on ALTINNTIDSPUNKTLEVERT from meta_xxxxxxxx.json, to ensure right format before converting from UTC to Oslo-time. 

Correct format is '2025-03-20T15:54:40.637235Z', but if miliseconds ends with one or multiple zeroes it will be truncated before it ends on meta-xxxxxxxxx.json file. Witch led to a ValueError when running isee_transform. The new function _pad_microseconds_to_six() ensures right format before converting.